### PR TITLE
Add circle ci, sonarcloud, and docker support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+# 
+
+# Configuration file for Circle CI 
+# CI will report failure if any executed command returns and error status
+# Operations performed are as follows
+# Build source code
+# Run unit tests for C++ and Java
+# Run static code analyzer for SourceCloud
+# Upload test results
+# Every run command should start with source ${INIT_ENV} to ensure all default dependancies are available
+
+jobs:
+  build:
+    # Pull docker image from docker hub
+    # XTERM used for better catkin_make output
+    docker:
+      - image: usdotfhwastol/carma-base:3.3.0
+        user: carma
+        environment:
+          TERM: xterm # use xterm to get full display output from build
+          INIT_ENV: /home/carma/.base-image/init-env.sh
+    working_directory: "/opt/carma/"
+    # Execution steps
+    steps:
+      - run:
+          name: Create src folder
+          command: |
+            source ${INIT_ENV}
+            mkdir src
+            cd src
+            mkdir CARMAGarminLidarLiteV3DriverWrapper
+      - checkout:
+          path: src/CARMAGarminLidarLiteV3DriverWrapper
+      - run: 
+          name: Pull Deps
+          command: |
+            source ${INIT_ENV}
+            ./src/CARMAGarminLidarLiteV3DriverWrapper/docker/checkout.sh ${PWD}
+      - run:
+          name: Build Driver
+          command: |
+            source ${INIT_ENV}
+            build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output bash make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
+      - run:
+          name: Run C++ Tests
+          command: |
+            source ${INIT_ENV}
+            bash make_with_coverage.bash -t -e /opt/carma/ -o ./coverage_reports/gcov
+      # Run SonarCloud analysis
+      # PR Branchs and number extracted from Circle variables and github api
+      # Circle CI seems to make a change to the base branch, so we must fetch --force to ensure correct git file change stats
+      # SONAR_SCANNER_TOKEN MUST be secured as an environment variable in Circle CI NOT in this file. 
+      # The following sonar settings MUST be set in SonarCloud UI NOT in this file
+      # sonar.pullrequest.provider
+      # sonar.pullrequest.github.endpoint
+      # sonar.pullrequest.github.token.secured
+      # sonar.pullrequest.github.repository
+      # Use -X on sonar-scanner to enable debug output
+      - run:
+          name: Run Sonar Scanner
+          command: |
+            source ${INIT_ENV}
+            if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
+              echo "Non-PR Build Detected. Running analysis on ${CIRCLE_BRANCH}"
+              cd src/CARMAGarminLidarLiteV3DriverWrapper
+              sonar-scanner -Dproject.settings=.sonarqube/sonar-scanner.properties -Dsonar.login=${SONAR_SCANNER_TOKEN} 
+              exit 0;
+            fi
+            echo "PR branch ${CIRCLE_BRANCH}"
+            echo "Repo name ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            echo "URL ${CIRCLE_PULL_REQUEST}"
+            export PR_NUM=`echo ${CIRCLE_PULL_REQUEST} | cut -d'/' -f7`
+            echo "PR number ${PR_NUM}"
+            export BASE_BRANCH_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUM}"
+            export TARGET_BRANCH=$(curl "$BASE_BRANCH_URL" | jq '.base.ref' | tr -d '"') 
+            echo "Target Branch = ${TARGET_BRANCH}"
+            cd src/CARMAGarminLidarLiteV3DriverWrapper
+            git fetch --force origin ${TARGET_BRANCH}:${TARGET_BRANCH}
+            sonar-scanner -Dproject.settings=.sonarqube/sonar-scanner.properties -Dsonar.login=${SONAR_SCANNER_TOKEN} -Dsonar.pullrequest.base=${TARGET_BRANCH} -Dsonar.pullrequest.branch=${CIRCLE_BRANCH} -Dsonar.pullrequest.key=${PR_NUM}

--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -1,0 +1,39 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# Configuration file for Sonar Scanner used for CI 
+
+sonar.projectKey=usdot-fhwa-stol_CARMAGarminLidarLiteV3DriverWrapper
+sonar.organization=usdot-fhwa-stol
+sonar.cfamily.build-wrapper-output=/opt/carma/bw-output
+sonar.host.url=https://sonarcloud.io
+sonar.sources=src/main
+sonar.cfamily.gcov.reportsPath=/opt/carma/coverage_reports/gcov
+sonar.tests=src/test
+# Set Git as SCM sensor
+sonar.scm.disabled=false
+sonar.scm.enabled=true
+sonar.scm.provider=git
+
+# Modules
+#sonar.modules=lidar_lite_v3hp # TODO uncomment
+
+#lidar_lite_v3hp.sonar.projectBaseDir=/opt/carma/src/CARMAGarminLidarLiteV3DriverWrapper/lidar_lite_v3hp # TODO uncomment
+
+# C++ Package differences
+# Sources
+#lidar_lite_v3hp.sonar.sources=src # TODO uncomment
+# Tests
+# Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
+#lidar_lite_v3hp.sonar.tests=test # TODO uncomment

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+USERNAME=usdotfhwastol
+
+cd "$(dirname "$0")"
+IMAGE=$(./get-image-name.sh | tr '[:upper:]' '[:lower:]')
+
+echo ""
+echo "##### $IMAGE Docker Image Build Script #####"
+echo ""
+
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case $arg in
+        -v|--version)
+            COMPONENT_VERSION_STRING="$2"
+            shift
+            shift
+            ;;
+        --system-release)
+            SYSTEM_RELEASE=true
+            shift
+            ;;
+        -p|--push)
+            PUSH=true
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$COMPONENT_VERSION_STRING" ]]; then
+    COMPONENT_VERSION_STRING=$("./get-component-version.sh")
+fi
+
+echo "Building docker image for $IMAGE version: $COMPONENT_VERSION_STRING"
+echo "Final image name: $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING"
+
+cd ..
+docker build --no-cache -t $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING \
+    --build-arg VERSION="$COMPONENT_VERSION_STRING" \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
+
+TAGS=()
+TAGS+=("$USERNAME/$IMAGE:$COMPONENT_VERSION_STRING")
+
+docker tag $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING $USERNAME/$IMAGE:latest
+TAGS+=("$USERNAME/$IMAGE:latest")
+
+echo "Tagged $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING as $USERNAME/$IMAGE:latest"
+
+if [ "$SYSTEM_RELEASE" = true ]; then
+    SYSTEM_VERSION_STRING=$("./get-system-version.sh")
+    docker tag $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING $USERNAME/$IMAGE:$SYSTEM_VERSION_STRING
+    echo "Tagged $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING as $USERNAME/$IMAGE:$SYSTEM_VERSION_STRING"
+    TAGS+=("$USERNAME/$IMAGE:$SYSTEM_VERSION_STRING")
+fi
+
+if [ "$PUSH" = true ]; then
+    for tag in $TAGS; do
+        docker push "${tag}"
+    done
+fi
+
+echo ""
+echo "##### $IMAGE Docker Image Build Done! #####"

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# CARMA packages checkout script
+# Optional argument to set the root checkout directory with no ending '/' default is '~'
+
+set -ex
+
+dir=~
+if [[ -n ${1} ]]; then
+      dir=${1}
+fi
+
+git clone https://github.com/usdot-fhwa-stol/CARMAMsgs.git ${dir}/src/CARMAMsgs --branch develop --depth 1
+git clone https://github.com/usdot-fhwa-stol/CARMAUtils.git ${dir}/src/CARMAUtils --branch develop --depth 1

--- a/docker/get-component-version.sh
+++ b/docker/get-component-version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+cd "$(dirname "$0")"
+cd ..
+COMPONENT_TAG_PREFIX="${PWD##*/}"
+git describe --all --match="$COMPONENT_TAG_PREFIX*" --always --dirty="-SNAPSHOT" | awk -F "/" '{print $NF}' | sed "s/$COMPONENT_TAG_PREFIX\_//"
+

--- a/docker/get-image-name.sh
+++ b/docker/get-image-name.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+cd "$(dirname "$0")"
+REPO_NAME="$(./get-repo-name.sh)"
+
+# This sed command based on Stack Overflow answer: https://stackoverflow.com/questions/28795479/awk-sed-script-to-convert-a-file-from-camelcase-to-underscores
+# Asked by Corentin Peuvrel: https://stackoverflow.com/users/4608146/corentin-peuvrel
+# Answered by pachopepe: https://stackoverflow.com/users/641896/pachopepe
+# Credited in accordance with Stack Overflow's CC-BY license
+echo $REPO_NAME | sed -r 's/CARMA/carma/' | sed -r 's/([A-Z])/-\L\1/g' | sed 's/^_//'
+

--- a/docker/get-repo-name.sh
+++ b/docker/get-repo-name.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+basename -s .git `git config --get remote.origin.url`

--- a/docker/get-system-version.sh
+++ b/docker/get-system-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+SYSTEM_TAG_PREFIX="CARMASystem"
+
+git describe --all --match="$SYSTEM_TAG_PREFIX*" --always --dirty="-SNAPSHOT" | awk -F "/" '{print $NF}'
+

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+sudo chmod -R +x /opt/carma/install
+source /opt/ros/kinetic/setup.bash
+cd ~/
+catkin_make install


### PR DESCRIPTION
Adds CI and docker support for this repo. The sonar cloud properties file currently contains commented out lines that I will have Ash uncomment in his PR to run analysis. 