### PR TITLE
Reduce job count for ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,13 @@ jobs:
           name: Build Driver
           command: |
             source ${INIT_ENV}
+            export ROS_PARALLEL_JOBS='-j1 -l1' # Try to reduce memory consumption on build
             build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output bash make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
       - run:
           name: Run C++ Tests
           command: |
             source ${INIT_ENV}
+            export ROS_PARALLEL_JOBS='-j1 -l1' # Try to reduce memory consumption on build
             bash make_with_coverage.bash -t -e /opt/carma/ -o ./coverage_reports/gcov
       # Run SonarCloud analysis
       # PR Branchs and number extracted from Circle variables and github api


### PR DESCRIPTION
In the driver PR it seems there might have been failure due to high memory usage. This change helps prevent that by capping the number of build jobs. 