### PR TITLE
Fix docker build for trailer angle sensor driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.4.0 as deps
+FROM usdotfhwastol/carma-base:3.5.0 as deps
 
 FROM deps as setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+FROM usdotfhwastol/carma-base:3.4.0 as deps
+
+FROM deps as setup
+
+RUN mkdir ~/src
+COPY --chown=carma . /home/carma/src/
+RUN ~/src/docker/checkout.sh
+RUN ~/src/docker/install.sh
+
+FROM deps
+
+ARG BUILD_DATE="NULL"
+ARG VERSION="NULL"
+ARG VCS_REF="NULL"
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="carma-garmin-lidar-lite-v3-trailer-angle-driver"
+LABEL org.label-schema.description="CARMA Garmin Lidar LiteV3 trailer angle sensor driver  for the CARMA Platform"
+LABEL org.label-schema.vendor="Leidos"
+LABEL org.label-schema.version=${VERSION}
+LABEL org.label-schema.url="https://highways.dot.gov/research/research-programs/operations/CARMA"
+LABEL org.label-schema.vcs-url="https://github.com/usdot-fhwa-stol/CARMAGarminLidarLiteV3DriverWrapper/"
+LABEL org.label-schema.vcs-ref=${VCS_REF}
+LABEL org.label-schema.build-date=${BUILD_DATE}
+
+COPY --from=setup /home/carma/install /opt/carma/install
+
+CMD [ "wait-for-it.sh", "localhost:11311", "--", "roslaunch", "lidar_lite_v3hp", "lidar_litev3hp.launch"]

--- a/lidar_lite_v3hp/CMakeLists.txt
+++ b/lidar_lite_v3hp/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(lidar_litev3hp_worker_lib src/lidar_litev3hp_worker.cpp)
 add_dependencies(lidar_litev3hp_worker_lib ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(lidar_litev3hp_node ${catkin_LIBRARIES})
+target_link_libraries(lidar_litev3hp_node lidar_litev3hp_worker_lib ${catkin_LIBRARIES})
 
 
 #############


### PR DESCRIPTION
Helps resolve usdot-fhwa-stol/CARMAPlatform#488

Adds the docker file which was missing from this repo and fixes a build linking issue which seems to only occur during the docker build. 

Should be merged after usdot-fhwa-stol/CARMABase#27 and the corresponding component release of carma-base is complete so that ci can build properly. 