### PR TITLE
TrailerAngleMsgUpdate

### DIFF
--- a/Instruction.md
+++ b/Instruction.md
@@ -1,6 +1,6 @@
 
 
-Instruction for setting up the Arduino (Use Arduino Uno or Higher )
+Instruction for setting up the Arduino (Use Arduino Uno or Higher ) and package.
 
 1) Wire the lidar lite v3 hp according to Setup Documentation Hardware: https://support.garmin.com/en-US/?partNumber=010-01722-00&tab=manuals
 
@@ -11,11 +11,23 @@ https://github.com/garmin/LIDARLite_Arduino_Library
 
 b)rosserial_arduino
 http://wiki.ros.org/rosserial_arduino/Tutorials/Arduino%20IDE%20Setup
+Note: Its better to use the rosserial from source over binary and do catkin_make install as this make sure everything is installed over just catkin_make
 
-2) Load the Arduino code and build it. Do the same for both the Arduino.
+2) Load the Arduino code and build it. Note sensor 1 code should be put in one Arduion and the other Arduino with sensor 2 code.
 
-3) Make sure to check the launch file and adjust the parameters as needed.
+3) Clone the CARMAMsgs repo into the src : https://github.com/usdot-fhwa-stol/CARMAMsgs.git.
+
+4) Connect both the Arduino controllers and check the ports using following
+
+a) ls -l /dev/ttyACM* and make sure /dev/ttyACM0 and /dev/ttyACM0 showsup.
+
+b) chmod 777 /dev/ttyACM0 and chmod 777 /dev/ttyACM1 to give port access to Arduino serial channel.
+
+5) Make sure to check the launch file and adjust the parameters as needed. The distance between the sensors mounted are currently set to 150 cm. Change this as per the mount requirement and update the configuration file. Its adviced to use distance of above 100 cm to avoid senor to sensor reflectivity interference.
 
 Note: Please use 100kHz I2C speed if using I2C wire length above 25 cm.
+
+
+
 
 

--- a/lidar_lite_v3hp/include/lidar_litev3hp_wrapper.h
+++ b/lidar_lite_v3hp/include/lidar_litev3hp_wrapper.h
@@ -25,6 +25,7 @@
 #include <message_filters/sync_policies/approximate_time.h>
 #include <cav_msgs/SystemAlert.h>
 #include <cav_msgs/DriverStatus.h>
+#include <cav_msgs/TrailerAngle.h>
 #include "lidar_litev3hp_worker.h"
 
 class LidarLiteNode
@@ -32,6 +33,7 @@ class LidarLiteNode
 
  private:
   cav_msgs::DriverStatus status_;
+  cav_msgs::TrailerAngle tangle_;
   message_filters::Subscriber<sensor_msgs::Range> sub_1_;
   message_filters::Subscriber<sensor_msgs::Range> sub_2_;
   ros::Publisher pub_ang_;

--- a/lidar_lite_v3hp/src/lidar_litev3hp_wrapper.cpp
+++ b/lidar_lite_v3hp/src/lidar_litev3hp_wrapper.cpp
@@ -37,6 +37,7 @@ LidarLiteNode::LidarLiteNode() : pnh_("~")
     double sensor_distance; //Distance between sensor
     pnh_.getParam("distance_between_two_sensor",sensor_distance);
     ROS_INFO_STREAM("sensor1= "<<sensor_inp1->range<<" "<<"sensor2= "<<sensor_inp2->range<<"sensor_distance= "<<sensor_distance);
+    tangle_.header.stamp=ros::Time::now();
     tangle_.angle=worker_.LidarLiteNodeWorker::trailerAngle(sensor_distance,sensor_inp1->range,sensor_inp2->range);
     pub_ang_.publish(tangle_);
   }

--- a/lidar_lite_v3hp/src/lidar_litev3hp_wrapper.cpp
+++ b/lidar_lite_v3hp/src/lidar_litev3hp_wrapper.cpp
@@ -37,10 +37,8 @@ LidarLiteNode::LidarLiteNode() : pnh_("~")
     double sensor_distance; //Distance between sensor
     pnh_.getParam("distance_between_two_sensor",sensor_distance);
     ROS_INFO_STREAM("sensor1= "<<sensor_inp1->range<<" "<<"sensor2= "<<sensor_inp2->range<<"sensor_distance= "<<sensor_distance);
-    std_msgs::Float64 msg_ang;
-    msg_ang.data=worker_.LidarLiteNodeWorker::trailerAngle(sensor_distance,sensor_inp1->range,sensor_inp2->range);
-    pub_ang_.publish(msg_ang);
-   
+    tangle_.angle=worker_.LidarLiteNodeWorker::trailerAngle(sensor_distance,sensor_inp1->range,sensor_inp2->range);
+    pub_ang_.publish(tangle_);
   }
 
     void LidarLiteNode::alertCallback(const cav_msgs::SystemAlertConstPtr &msg)


### PR DESCRIPTION
The trailer angle reported by the CARMAGarminLidarLiteV3DriverWrapper is published as an std_msgs/Float64 message type. It is difficult to use this message type reliably as it does not contain a timestamp which can be used for transform lookups. It should be updated to use a message type containing a header.